### PR TITLE
Improve sitemap generation with git-based timestamps and hreflang

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,20 +1,31 @@
+import { execSync } from 'node:child_process'
+import type { MetadataRoute } from 'next'
 import { locales } from '@/i18n'
 
 export const dynamic = 'force-static'
 
-export default function sitemap() {
+const lastModified: string = (() => {
+  try {
+    return execSync('git log -1 --format=%cI', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim()
+  } catch {
+    return new Date().toISOString()
+  }
+})()
+
+export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://alexeibostan.com'
-  
-  const pages = ['']
-  
-  const urls = locales.flatMap((locale) =>
-    pages.map((page) => ({
-      url: `${baseUrl}/${locale}${page}`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly' as const,
-      priority: page === '' ? 1 : 0.8,
-    }))
+
+  const languages = Object.fromEntries(
+    locales.map((l) => [l, `${baseUrl}/${l}/`])
   )
 
-  return urls
+  return locales.map((locale) => ({
+    url: `${baseUrl}/${locale}/`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 1,
+    alternates: { languages },
+  }))
 }


### PR DESCRIPTION
## Summary
Enhanced the sitemap generation to use git commit timestamps for `lastModified` values and add hreflang alternate language links for better SEO and internationalization support.

## Key Changes
- **Git-based timestamps**: The `lastModified` field now uses the latest git commit timestamp (`git log -1 --format=%cI`) instead of the current date, providing more accurate modification tracking. Falls back to current date if git is unavailable.
- **Type safety**: Added explicit `MetadataRoute.Sitemap` return type annotation for better type checking.
- **Hreflang support**: Added `alternates.languages` object to each sitemap entry, mapping all supported locales to their respective URLs for improved SEO and multi-language site discovery.
- **Simplified structure**: Refactored the URL generation logic to be more concise and maintainable, removing unnecessary intermediate variables.
- **Consistent priority**: Set all entries to priority 1 (previously varied between 1 and 0.8).

## Implementation Details
- The `lastModified` value is computed once at module load time using an IIFE with error handling
- The `languages` object is constructed from all available locales, enabling search engines to discover all language variants
- Maintains the 'force-static' dynamic mode for optimal performance

https://claude.ai/code/session_01TGhfF4CLt5TiewbR4Twdyw