### PR TITLE
fix(seo,docs): trailing slashes in hreflang and sync CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,7 @@ src/
 │   └── [locale]/               # Locale-based dynamic routing
 │       ├── layout.tsx          # i18n-aware layout
 │       ├── Body.tsx            # Body wrapper with language detection
-│       ├── page.tsx            # Home page
-│       ├── about/page.tsx      # About page
-│       ├── projects/page.tsx   # Projects page
-│       └── skills/page.tsx     # Skills page (hexagonal grid)
+│       └── page.tsx            # Single-page portfolio (hero, work, craft, AI, connect sections)
 ├── components/
 │   ├── layout/                 # Layout components (Header, Footer, Layout, LanguageSwitcher)
 │   ├── StructuredData.tsx      # JSON-LD schema renderer

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -57,10 +57,10 @@ export function generateSEOMetadata(config: SEOConfig): Metadata {
     alternates: {
       canonical: url,
       languages: {
-        en: `${baseUrl}/en`,
-        nl: `${baseUrl}/nl`,
-        it: `${baseUrl}/it`,
-        ro: `${baseUrl}/ro`,
+        en: `${baseUrl}/en/`,
+        nl: `${baseUrl}/nl/`,
+        it: `${baseUrl}/it/`,
+        ro: `${baseUrl}/ro/`,
       },
     },
     openGraph: {


### PR DESCRIPTION
## Summary

- `src/lib/metadata.ts`: append `/` to every entry in `alternates.languages` so the generated `<link rel="alternate" hreflang="…">` URLs match the `trailingSlash: true` convention already used in `next.config.mjs` and `src/app/sitemap.ts`. Previously each hreflang URL triggered a redirect hop (e.g. `/en` → `/en/`), weakening the signal.
- `CLAUDE.md`: remove the stale `about/page.tsx`, `projects/page.tsx`, and `skills/page.tsx` entries from the Project Structure tree. Those routes were removed in the single-page redesign (commit `3974ec5`); the current `src/app/[locale]/` directory only holds `layout.tsx`, `Body.tsx`, and `page.tsx`.

## Test plan

- [ ] `bun run lint`
- [ ] `bun run build` — confirm static export succeeds
- [ ] Inspect `build/en/index.html` `<head>` and confirm each `<link rel="alternate" hreflang="…">` `href` ends with `/`
- [ ] Parse `build/sitemap.xml` (e.g. `xmllint --noout build/sitemap.xml`) and confirm every `<loc>` and `<xhtml:link href="…">` also ends with `/`, matching the new `metadata.ts` map
- [ ] `bun run seo:validate` against `bun dev` to confirm hreflang URLs resolve without redirects
- [ ] Re-read `CLAUDE.md` Project Structure against `ls src/app/[locale]/` output
