### PR TITLE
Add company details to copyright footer

### DIFF
--- a/src/components/sections/ConnectSection.tsx
+++ b/src/components/sections/ConnectSection.tsx
@@ -110,8 +110,9 @@ export function ConnectSection() {
         </div>
 
         {/* Copyright */}
-        <p className="mt-12 text-[11px] opacity-50 font-mono-brand">
+        <p className="mt-12 text-[11px] opacity-50 font-mono-brand max-w-[640px] leading-relaxed px-4">
           {t("copyright", { year: new Date().getFullYear() })}
+          {" · Bostan Software Developments · Trekvogelweg 229, 3815 LH Amersfoort, NL · KvK 94926697 · VAT NL005118619B33"}
         </p>
       </section>
     </footer>


### PR DESCRIPTION
## Summary
Added company information and legal details to the copyright notice in the footer section.

## Changes
- Updated the copyright paragraph in `ConnectSection.tsx` with improved styling:
  - Added `max-w-[640px]` constraint for better readability
  - Added `leading-relaxed` for improved line spacing
  - Added `px-4` for horizontal padding on smaller screens
- Appended company details to the copyright text:
  - Company name: Bostan Software Developments
  - Physical address: Trekvogelweg 229, 3815 LH Amersfoort, NL
  - Chamber of Commerce (KvK) registration: 94926697
  - VAT number: NL005118619B33

## Implementation Details
The company information is hardcoded as a string literal appended to the translated copyright text. This ensures the legal details are always displayed alongside the dynamic year in the copyright notice.

https://claude.ai/code/session_01B8vjFh3EJJF5W5hFV8yvs7