### PR TITLE
Update resume filename to professional naming convention

### DIFF
--- a/src/components/sections/ConnectSection.tsx
+++ b/src/components/sections/ConnectSection.tsx
@@ -101,7 +101,7 @@ export function ConnectSection() {
         {/* Resume download */}
         <div className="mt-5">
           <a
-            href="/alexei-bostan-resume.pdf"
+            href="/Alexei-Bostan-Professional-Resume.pdf"
             download
             className="inline-flex items-center gap-2 font-mono-brand text-[11px] text-[hsl(var(--primary))] opacity-70 hover:opacity-100 transition-opacity border-b border-[hsl(var(--primary))]/30 hover:border-[hsl(var(--primary))]/60 pb-0.5 tracking-[1px]"
           >


### PR DESCRIPTION
## Summary
Updated the resume download link filename to follow a more professional naming convention with proper capitalization and descriptive terminology.

## Changes
- Changed resume file reference from `/alexei-bostan-resume.pdf` to `/Alexei-Bostan-Professional-Resume.pdf` in the ConnectSection component

## Details
This change updates the resume download link in the Connect section to use a more polished filename that better reflects professional standards. The new filename includes:
- Proper name capitalization (Alexei Bostan)
- "Professional" descriptor for clarity
- Consistent hyphenation

Note: The actual PDF file in the public directory should be renamed to match this new reference to maintain the download functionality.

https://claude.ai/code/session_01G9uMWTUB7ncv56ex9xAzqK